### PR TITLE
Fix CSS reloading

### DIFF
--- a/config/esbuild.defaults.js
+++ b/config/esbuild.defaults.js
@@ -216,7 +216,7 @@ module.exports = postcssrc().then((postCssConfig) => {
       await context.watch();
     } else {
       await context.rebuild();
+      context.dispose();
     }
-    context.dispose();
   };
 });


### PR DESCRIPTION
Apparently, we need to not `dispose` of the `watch()` context.