### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -4,7 +4,7 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   verify_or_deploy:
@@ -37,7 +37,7 @@ jobs:
           DISABLE_SOURCE_MAPS: 1
 
       - name: Deploy
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/src/_layouts/post.erb
+++ b/src/_layouts/post.erb
@@ -16,7 +16,7 @@ layout: default
   </div>
   <div>
     <small>
-      <a href="https://github.com/davidrunger/blog/edit/master/src/<%= resource.relative_path %>">
+      <a href="https://github.com/davidrunger/blog/edit/main/src/<%= resource.relative_path %>">
         Fork and edit this article on GitHub
       </a>
     </small>


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.