### PR TITLE
Bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -12,7 +12,7 @@ jobs:
     name: Verify deployability (and maybe deploy)
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This fixes a deprecation warning about "Node.js 16 actions are deprecated".