### PR TITLE
Bump actions/setup-node from v3 to v4

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -20,7 +20,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.12.1
 


### PR DESCRIPTION
This fixes a deprecation warning about "Node.js 16 actions are deprecated".