### PR TITLE
Move from cloudflare/pages-action to cloudflare/wrangler-action

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -38,9 +38,8 @@ jobs:
 
       - name: Deploy
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: david-runger-blog
-          directory: output
+          command: pages deploy output --project-name=david-runger-blog


### PR DESCRIPTION
Fixes a Node 16 deprecation warning that occurs on cloudflare/pages-action. See: https://github.com/cloudflare/pages-action/issues/ 117#issuecomment-2053610761