### PR TITLE
Bump node from 18.12.1 to 20.14.0

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.12.1
+          node-version: 20.14.0
 
       - name: Install Gems
         run: bundle install


### PR DESCRIPTION
I believe that this is the latest stable ("active") release of Node. https://nodejs.org/en/about/previous-releases