### PR TITLE
Fetch full git history in GitHub Action (for accurate timestamps)

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The `bridgetown-sitemap` gem uses the git history to determine the last modified time of each post (if one is not manually specified in the post's frontmatter).

Prior to this change, we were only fetching the latest commit, and so we were not able to determine (using git) an accurate `lastmod` time for each of the sitemap entries.

With this change, we will now fetch the full git history, which should allow `bridgetown-sitemap` to correctly determine the time at which each article was last modified.