### PR TITLE
Use 'plugin :bridgetown_server' to address deprecation [BLOG-5]

### DIFF
--- a/server/roda_app.rb
+++ b/server/roda_app.rb
@@ -12,8 +12,5 @@ class RodaApp < Roda
   # Some Roda configuration is handled in the `config/initializers.rb` file.
   # But you can also add additional Roda configuration here if needed.
 
-  route do |r|
-    # Load Roda routes in server/routes (and src/_routes via `bridgetown-routes`)
-    r.bridgetown
-  end
+  route(&:bridgetown)
 end

--- a/server/roda_app.rb
+++ b/server/roda_app.rb
@@ -4,23 +4,16 @@
 # on the concept of a routing tree. Bridgetown uses it for its development
 # server, but you can also run it in production for fast, dynamic applications.
 #
-# Learn more at: http://roda.jeremyevans.net
+# Learn more at: https://www.bridgetownrb.com/docs/routes
 
-# Uncomment to use file-based dynamic routing in your project (make sure you
-# uncomment the gem dependency in your Gemfile as well):
-# require "bridgetown-routes"
+class RodaApp < Roda
+  plugin :bridgetown_server
 
-class RodaApp < Bridgetown::Rack::Roda
-  # Add additional Roda configuration here if needed
+  # Some Roda configuration is handled in the `config/initializers.rb` file.
+  # But you can also add additional Roda configuration here if needed.
 
-  # Uncomment to use Bridgetown SSR:
-  # plugin :bridgetown_ssr
-
-  # And optionally file-based routing:
-  # plugin :bridgetown_routes
-
-  route do |_r|
+  route do |r|
     # Load Roda routes in server/routes (and src/_routes via `bridgetown-routes`)
-    Bridgetown::Rack::Routes.start!(self)
+    r.bridgetown
   end
 end


### PR DESCRIPTION
> Deprecation: The `Bridgetown::Rack::Roda' class will be removed in > favor of using the `bridgetown_server' plugin in a future version

The error message isn't clear, but I guessed how to do this by looking at: https://github.com/bridgetownrb/bridgetown/pull/ 737/files#diff-1a65d8205fc2fce0e4b8e7d496c04f8bf62fa33be047c6c32e87a3a2ccd46aab