### PR TITLE
Remove quotes from title in frontmatter (in bin script and posts)

### DIFF
--- a/bin/create-post
+++ b/bin/create-post
@@ -17,7 +17,7 @@ path = "src/_posts/#{filename}"
 File.open(path, 'w+') do |file|
   file.puts(<<~FRONTMATTER)
     ---
-    title: "#{title}"
+    title: #{title}
     subtitle:
     ---
   FRONTMATTER

--- a/src/_posts/2023-01-30-mocking-external-requests-in-rails-feature-tests.md
+++ b/src/_posts/2023-01-30-mocking-external-requests-in-rails-feature-tests.md
@@ -1,6 +1,6 @@
 ---
-title: "Mocking external requests in Rails feature tests"
-subtitle: "essentially, WebMock for the (test) browser"
+title: Mocking external requests in Rails feature tests
+subtitle: essentially, WebMock for the (test) browser
 ---
 
 Without any introduction, allow me to share some code that I want to talk about, which exists within

--- a/src/_posts/2023-02-13-quick-tip:-use-gem.wtf-to-go-to-the-github-repo-of-a-gem.md
+++ b/src/_posts/2023-02-13-quick-tip:-use-gem.wtf-to-go-to-the-github-repo-of-a-gem.md
@@ -1,6 +1,5 @@
 ---
 title: "Quick Tip: Use gem.wtf to go to the GitHub repo of a gem"
-subtitle:
 ---
 
 [gem.wtf](https://gem.wtf/) is a handy little website/tool that I use probably at least once a week.

--- a/src/_posts/2024-07-02-enforce-git-hooks-in-a-rails-initializer.md
+++ b/src/_posts/2024-07-02-enforce-git-hooks-in-a-rails-initializer.md
@@ -1,6 +1,5 @@
 ---
-title: "Enforce Git hooks in a Rails initializer"
-subtitle:
+title: Enforce Git hooks in a Rails initializer
 ---
 
 ## Git hooks

--- a/src/_posts/2024-07-25-flaky-parallel-specs-caused-by-actioncable.md
+++ b/src/_posts/2024-07-25-flaky-parallel-specs-caused-by-actioncable.md
@@ -1,6 +1,6 @@
 ---
-title: "Flaky specs due to ActionCable leakage"
-subtitle: "A cautionary tale"
+title: Flaky specs due to ActionCable leakage
+subtitle: A cautionary tale
 ---
 
 ## A spec setup at risk of flaking


### PR DESCRIPTION
The quotes are usually not needed, and I sort of don't like having them.

While we're at it, let's also delete blank `subtitle`s.