### PR TITLE
[deploy] Empty (rather than delete) the existing 'blog/' directory

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -31,9 +31,9 @@ runs:
       shell: bash
       run: mv output blog
 
-    - name: Delete existing 'blog/' directory on server
+    - name: Empty existing 'blog/' directory contents on server
       shell: bash
-      run: ssh "${{ inputs.SERVER_USER_AND_IP }}" "rm -rf /root/david_runger/blog"
+      run: ssh "${{ inputs.SERVER_USER_AND_IP }}" "rm -rf /root/david_runger/blog/{*,.*}"
 
     - name: Copy 'blog/' directory to server
       shell: bash


### PR DESCRIPTION
It seems that fully deleting the directory is breaking the Docker volume connection between the server host and the Docker containers. Hopefully just emptying the directory won't break the connection.