### PR TITLE
[seo-tags] Remove double '/blog' path fragments

### DIFF
--- a/src/_partials/_head.erb
+++ b/src/_partials/_head.erb
@@ -3,9 +3,9 @@
 <style>html { visibility: hidden; opacity:0; }</style>
 <% if resource.data.skip_seo_title %>
   <title>David Runger : Blog</title>
-  <%= seo(title: false) %>
+  <%= seo(title: false).gsub('blog/blog', 'blog') %>
 <% else %>
-  <%= seo %>
+  <%= seo.gsub('blog/blog', 'blog').html_safe %>
 <% end %>
 <%= feed_meta %>
 <link rel="icon" type="image/png" sizes="32x32" href="<%= site.base_path %>/images/favicon/favicon-32x32.png">


### PR DESCRIPTION
I'm not sure if this is a bug in `bridgetown-seo-tag`, or something that I am doing wrong, but, whatever the cause, in production, we currently have two URL references in the SEO tags on each blog show page that are like https://davidrunger.com/blog/blog/mocking-external-requests-in-rails-feature-tests with `/blog/blog`. This change condenses that down to just one `/blog`.

This is hacky, but I think it's fine. There's probably a better way to fix this (maybe an upstream bugfix), but I'm just going to do it this way, for now.