### PR TITLE
[footer] Improve Atom feed icon vertical alignment [BLOG-13]

### DIFF
--- a/src/_partials/_footer.erb
+++ b/src/_partials/_footer.erb
@@ -3,7 +3,7 @@
     <div>
       <a href="/blog/feed.xml">
         <%= svg "/images/icons/feed.svg", height: '1.2em' %>
-        Atom Feed
+        <span class="align-middle">Atom Feed</span>
       </a>
     </div>
     <div>


### PR DESCRIPTION
... by applying `vertical-align: middle` to the adjacent _text_ element! I had initially spent all of my time focusing on what CSS I could apply to the _icon_.

Shoutout to https://christopheraue.net/design/vertical-align#centering-an-icon for helping me with this insight.

---

# Before

![image](https://github.com/user-attachments/assets/33bb2f6e-a191-4db5-885c-78da6da9aa5a)

# After

![image](https://github.com/user-attachments/assets/12bebab3-08a6-49fc-aa9e-0e05a9a98fc4)

Subtle, but better.