### PR TITLE
Limit concurrency of GitHub actions

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   verify_or_deploy:
+    concurrency:
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+      group: verify_or_deploy-${{ github.ref_name }}
     runs-on: ubuntu-latest
     name: Verify deployability (and maybe deploy)
     steps:


### PR DESCRIPTION
On PR branches, we will cancel any in-progress runs.

On `main`, we will _not_ cancel any in-progress runs (since I worry that cancelling a deployment partway through could potentially leave things in a bad/broken state).

Part of the motivation for this change is that I'm wondering if it will avoid deployment failures like this one: https://github.com/davidrunger/blog/actions/runs/10557822510/job/29246127443#step:9:45

```
scp: /root/david_runger/blog/_bridgetown/static/index.H254IC7J.css: No such file or directory
```