### PR TITLE
Include script for local david_runger build

### DIFF
--- a/bin/build-to-local-david_runger
+++ b/bin/build-to-local-david_runger
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# This script is used to build the site and deploy it to the `david_runger`
+# directory in my `code` directory. (It won't work on your machine, unless you
+# set up the same directory structure.)
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+BRIDGETOWN_ENV=production bin/bridgetown deploy
+rm -rf ~/code/david_runger/blog
+mv output blog
+cp -r blog ~/code/david_runger
+rm -rf blog


### PR DESCRIPTION
This can be used to test the david_runger<=>blog integration locally. This is basically a local version of the GitHub Actions in this repo that build this blog and push the compiled files to my davidrunger.com production server.