### PR TITLE
[ci] Perform sanity check that CSS assets have compiled correctly

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -43,6 +43,9 @@ jobs:
         env:
           BRIDGETOWN_ENV: production
 
+      - name: Check compiled CSS
+        run: bin/check-compiled-css
+
       - name: Deploy
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: ./.github/actions/deploy

--- a/bin/check-compiled-css
+++ b/bin/check-compiled-css
@@ -5,6 +5,6 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 # Check that a 'visibility:' CSS rule is present in the compiled CSS.
 css_target='visibility:'
 if ! grep -q "$css_target" output/_bridgetown/static/index.*.css ; then
-  echo "ERROR: No '$css_target' CSS rule found in compiled CSS."
+  echo "ERROR: There is no '$css_target' CSS rule in the compiled CSS."
   exit 1
 fi

--- a/bin/check-compiled-css
+++ b/bin/check-compiled-css
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Check that a 'visibility:' CSS rule is present in the compiled CSS.
+grep -q 'visibility:' output/_bridgetown/static/index.*.css

--- a/bin/check-compiled-css
+++ b/bin/check-compiled-css
@@ -3,4 +3,7 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 # Check that a 'visibility:' CSS rule is present in the compiled CSS.
-grep -q 'visibility:' output/_bridgetown/static/index.*.css
+if ! grep -q 'visibility:' output/_bridgetown/static/index.*.css ; then
+  echo "ERROR: No 'visibility:' CSS rule found in compiled CSS."
+  exit 1
+fi

--- a/bin/check-compiled-css
+++ b/bin/check-compiled-css
@@ -3,7 +3,8 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 # Check that a 'visibility:' CSS rule is present in the compiled CSS.
-if ! grep -q 'visibility:' output/_bridgetown/static/index.*.css ; then
-  echo "ERROR: No 'visibility:' CSS rule found in compiled CSS."
+css_target='visibility:'
+if ! grep -q "$css_target" output/_bridgetown/static/index.*.css ; then
+  echo "ERROR: No '$css_target' CSS rule found in compiled CSS."
   exit 1
 fi

--- a/frontend/styles/elements.css
+++ b/frontend/styles/elements.css
@@ -317,6 +317,6 @@ article > h2 {
 
 /* https://stackoverflow.com/a/53364612/4009384  */
 html {
-  visibility: visible;
+  visibilityz: visible;
   opacity: 1;
 }

--- a/frontend/styles/elements.css
+++ b/frontend/styles/elements.css
@@ -317,6 +317,6 @@ article > h2 {
 
 /* https://stackoverflow.com/a/53364612/4009384  */
 html {
-  visibilityz: visible;
+  visibility: visible;
   opacity: 1;
 }


### PR DESCRIPTION
PR #472 ("Bump tailwindcss from 3.4.17 to 4.0.0") breaks CSS compilation, but still passes CI. This change will make CI fail for that PR (which is what we want, since it's a breaking change that does indeed break the site).