### PR TITLE
[posts/rails-app-update] Use $(pwd) (not hardcoded absolute path)

### DIFF
--- a/src/_posts/2024-06-26-using-vs-code-as-a-rails-app:update-merge-tool.md
+++ b/src/_posts/2024-06-26-using-vs-code-as-a-rails-app:update-merge-tool.md
@@ -104,10 +104,10 @@ rm "$RAILS_DEFAULT_CONFIG"
 
 Then, run `rails app:update` again, this time providing the above script as the `THOR_MERGE` tool.
 
-**Note:** It's important to provide the THOR_MERGE tool as an absolute path. Since your absolute path will be different from mine, you'll need to tweak the command below to reflect the absolute path to the location of your `app_update_thor_merge_tool` file.
+**Note:** It's important to provide the THOR_MERGE tool as an absolute path.
 
 ```
-THOR_MERGE=/home/david/code/david_runger/bin/app_update_thor_merge_tool bin/rails app:update
+THOR_MERGE=$(pwd)/bin/app_update_thor_merge_tool bin/rails app:update
 ```
 
 Now, if we press `m` (for `merge, run merge tool`) when prompted with a config file that needs attention, VS Code will open its three-way merge view:


### PR DESCRIPTION
I got this idea by noticing that a ChatGPT user agent was visiting this blog article. That made me curious to see whether and how ChatGPT would reference the article in a chat. I prompted: "How can I use VS Code as a merge tool for Rails's `app:update` command?", and it replied largely with a summary of my article, but it included this slick and very sensible change, which allows me to avoid the somewhat awkward mention about how my absolute path will differ from the reader's and which also makes it more convenient for the reader to simply copy-paste the command.