### PR TITLE
Darken blue text (to increase contrast) in light mode [BLOG-23]

### DIFF
--- a/frontend/styles/elements.css
+++ b/frontend/styles/elements.css
@@ -11,7 +11,6 @@
   --bg-dark-color: #e6e6e6;
   --border-color: #dbdbdb;
   --border-hover-color: #b5b5b5;
-  --code-background-color: inherit;
   --code-text-color: #00569c;
   --danger-color: #f14668;
   --danger-hover-color: #f03a5f;
@@ -37,7 +36,6 @@
     --bg-dark-color: #17171a;
     --border-color: #5f6267;
     --border-hover-color: #bcbebd;
-    --code-background-color: #292b2e;
     --code-text-color: #63b9ff;
     --danger-color: #770018;
     --danger-hover-color: #6b0015;
@@ -226,13 +224,11 @@ li {
 }
 
 pre {
-  background-color: var(--code-background-color);
   border-radius: 0;
 }
 
 code {
   color: var(--code-text-color);
-  background-color: var(--code-background-color);
 }
 
 a,

--- a/frontend/styles/elements.css
+++ b/frontend/styles/elements.css
@@ -11,8 +11,8 @@
   --bg-dark-color: #e6e6e6;
   --border-color: #dbdbdb;
   --border-hover-color: #b5b5b5;
-  --code-background-color: var(--highlighted-background-color);
-  --code-text-color: #29a0ff;
+  --code-background-color: inherit;
+  --code-text-color: #00569c;
   --danger-color: #f14668;
   --danger-hover-color: #f03a5f;
   --danger-text-background-color: #fde0e6;


### PR DESCRIPTION
## Dark mode before and after

![image](https://github.com/user-attachments/assets/93dba1a2-4b5b-4485-9f03-43c3242f8866)

![image](https://github.com/user-attachments/assets/f4ca140c-a9c2-4bab-95a3-9aa29406bf47)

## Light mode before and after

https://percy.io/David-Runger/web/blog/builds/39234079/changed/2116916020

![image](https://github.com/user-attachments/assets/919f6c17-cb99-44e6-9e10-853905144499)