### PR TITLE
[posts/mocking-requests] Update Mozilla CSP link

### DIFF
--- a/src/_posts/2023-01-30-mocking-external-requests-in-rails-feature-tests.md
+++ b/src/_posts/2023-01-30-mocking-external-requests-in-rails-feature-tests.md
@@ -43,11 +43,7 @@ website](https://davidrunger.com/) using Google OAuth. That test was added in
 
 ### Content Security Policy (CSP)
 
-I had previously introduced a bug when modifying my app's [Content Security Policy
-(CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). Setting up an effective CSP can be a
-little annoying, and there's a risk of introducing bugs when doing it (as happened to me), but the
-upside is that a well-crafted CSP can provide a significant amount of protection against various
-potential security vulnerabilities in a web app.
+I had previously introduced a bug when modifying my app's [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP). Setting up an effective CSP can be a little annoying, and there's a risk of introducing bugs when doing it (as happened to me), but the upside is that a well-crafted CSP can provide a significant amount of protection against various potential security vulnerabilities in a web app.
 
 ### OAuth
 


### PR DESCRIPTION
Email that I received today:

> Link to https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP did not return expected status
>
> We made a request to https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP, which is linked from https://davidrunger.com/blog/mocking-external-requests-in-rails-feature-tests, and its response status was 301, but we expected it to be in [200].

This change should fix that.

Also, remove hard wrapping of the paragraph. I think I am going to stop hard wrapping paragraphs in the blog and rely on developers and their tools to handle that for them, as needed. The advantage of this is that it will eliminate some unnecessary git diff noise when changing the length of some text relatively early in a paragraph that affects how the rest of the paragraph wraps.