### PR TITLE
Pin all GitHub Actions to a particular SHA [BLOG-24]

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -15,17 +15,17 @@ jobs:
     name: Verify deployability (and maybe deploy)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@922ebc4c5262cd14e07bb0e1db020984b6c064fe # v1.226.0
         with:
           bundler-cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: '.nvmrc'
 


### PR DESCRIPTION
This will make us less vulnerable to supply chain attacks like this one: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised .

`blog` has access to `secrets.SSH_PRIVATE_KEY`, etc, so it's important to secure it's GitHub Actions.