### PR TITLE
Update GitHub Actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:04"
+      timezone: America/Chicago
   - package-ecosystem: bundler
     directory: "/"
     schedule:


### PR DESCRIPTION
I think that this will be more valuable/important in light of #563, in which we pinned all GitHub Actions to a specific SHA?