### PR TITLE
Change link text for GitHub editing to "Improve this page"

### DIFF
--- a/frontend/styles/elements.css
+++ b/frontend/styles/elements.css
@@ -18,8 +18,8 @@
   --danger-text-color: #fff;
   --highlighted-background-color: #f5f5f5;
   --link-active-color: #363636;
-  --link-color: #443d8e;
-  --link-hover-color: #212121;
+  --link-color: #0065a0;
+  --link-hover-color: #008d9c;
   --link-visited-color: #443d8e;
   --success-color: #48c774;
   --success-hover-color: #3ec46d;
@@ -296,6 +296,10 @@ article > :not(.highlighter-rouge, p:has(img)) {
   width: 90%;
   margin-left: auto;
   margin-right: auto;
+}
+
+article a {
+  text-decoration: underline;
 }
 
 article > h2 {

--- a/frontend/styles/elements.css
+++ b/frontend/styles/elements.css
@@ -18,8 +18,8 @@
   --danger-text-color: #fff;
   --highlighted-background-color: #f5f5f5;
   --link-active-color: #363636;
-  --link-color: #0065a0;
-  --link-hover-color: #008d9c;
+  --link-color: #443d8e;
+  --link-hover-color: #212121;
   --link-visited-color: #443d8e;
   --success-color: #48c774;
   --success-hover-color: #3ec46d;
@@ -296,10 +296,6 @@ article > :not(.highlighter-rouge, p:has(img)) {
   width: 90%;
   margin-left: auto;
   margin-right: auto;
-}
-
-article a {
-  text-decoration: underline;
 }
 
 article > h2 {

--- a/src/_layouts/post.erb
+++ b/src/_layouts/post.erb
@@ -11,16 +11,22 @@ layout: default
       <%= resource.data.subtitle %>
     </p>
   </hgroup>
-  <div>
-    <small class="lowlighted">
-      <%= resource.date.strftime("%B %d, %Y") %> · <%= resource.data.author %> |
-      <a href="https://github.com/davidrunger/blog/edit/main/src/<%= resource.relative_path %>">
-        Edit this article on GitHub
-      </a>
-    </small>
+  <div class="text-sm">
+    <div class="lowlighted">
+      <%= resource.date.strftime("%B %d, %Y") %>
+      <span class="mx-1">·</span>
+      <%= resource.data.author %>
+    </div>
   </div>
 
   <%= yield %>
+
+  <div class="mt-2 text-center text-sm">
+    <span class="text-neutral-400">This blog is open source.</span>
+    <a href="https://github.com/davidrunger/blog/edit/main/src/<%= resource.relative_path %>">
+      Improve this post.
+    </a>
+  </div>
 </article>
 
 <div id="comments"></div>

--- a/src/_layouts/post.erb
+++ b/src/_layouts/post.erb
@@ -11,7 +11,7 @@ layout: default
       <%= resource.data.subtitle %>
     </p>
   </hgroup>
-  <div class="text-sm">
+  <div class="text-base">
     <div class="lowlighted">
       <%= resource.date.strftime("%B %d, %Y") %>
       <span class="mx-1">·</span>

--- a/src/_layouts/post.erb
+++ b/src/_layouts/post.erb
@@ -22,7 +22,7 @@ layout: default
   <%= yield %>
 
   <div class="mt-2 text-center text-sm">
-    <span class="text-neutral-400">This blog is open source.</span>
+    <span class="text-neutral-700 dark:text-neutral-400">This blog is open source.</span>
     <a href="https://github.com/davidrunger/blog/edit/main/src/<%= resource.relative_path %>">
       Improve this post.
     </a>


### PR DESCRIPTION
I saw that here https://tools.simonwillison.net/ and I think it's a nice improvement over "Edit this page". It provides a more compelling reason for the reader to act, and it has a more positive and progressive feel to it.

Also say "This blog is open source."

Also, move this stuff to the bottom of the page, rather than cluttering the top with the date and author info before the user has yet even had a chance to read the article.

### Before

![image](https://github.com/user-attachments/assets/cb4af3b8-6852-4485-a42c-28e7b80c2c82)

### After

![image](https://github.com/user-attachments/assets/121b8456-823c-477c-ad85-642a66021e5c)

![image](https://github.com/user-attachments/assets/d9df1478-1268-4cdd-980d-f8cb13522cd0)