### PR TITLE
[footer] Remove year from copyright notice [BLOG-27]

### DIFF
--- a/src/_partials/_footer.erb
+++ b/src/_partials/_footer.erb
@@ -7,10 +7,10 @@
       </a>
     </div>
     <div>
-      © <%= site.time.year %> by <a href="https://davidrunger.com/">David Runger</a>
+      View source at <a href="https://github.com/davidrunger/blog/">GitHub</a>
     </div>
     <div>
-      View source at <a href="https://github.com/davidrunger/blog/">GitHub</a>
+      © <a href="https://davidrunger.com/">David Runger</a>
     </div>
   </small>
 </footer>


### PR DESCRIPTION
I read on Reddit*, I think, that the year is not supposed to be the current year, but rather the year that the material was created and/or updated or something? Anyway, let's just remove it. I highly doubt that it's ever going to really matter to me or anyone else whether I have the year in the copyright notice or not.

*a reliable source of legal advice :-p

Also, move the copyright notice below the "View source at GitHub" link. I think that the copyright notice is relatively less important to me and to readers than the GitHub link, so I think it should appear later.