### PR TITLE
Specify 'margin: 0 auto' for post body using CSS class

### DIFF
--- a/frontend/styles/index.css
+++ b/frontend/styles/index.css
@@ -5,6 +5,13 @@
 @import 'pygments.css';
 @import 'copy-buttons.css';
 
+/* This class will be applied to `body` for posts via `resource.data.layout`. We
+are specifying this CSS here via a class to override Tailwind reset that is
+pulled in when rendered via `david_runger`. */
+.post {
+  margin: 0 auto;
+}
+
 .posts-li-title {
   font-size: 1.35rem;
   line-height: 1.8rem;


### PR DESCRIPTION
The `.post` class will be applied to `body` for posts, via `resource.data.layout` in `src/_layouts/default.erb`. We are specifying this CSS here via a class to override Tailwind reset for `body` that gives `margin: 0`. As part of https://davidrunger.atlassian.net/browse/COM- 9 , we will start pulling in the Tailwind reset (and Tailwind styles) when rendering the blog via `david_runger`.