### PR TITLE
Change code text color from greenish to pinkish(-purplish)

### DIFF
--- a/frontend/styles/elements.css
+++ b/frontend/styles/elements.css
@@ -11,7 +11,7 @@
   --bg-dark-color: #e6e6e6;
   --border-color: #dbdbdb;
   --border-hover-color: #b5b5b5;
-  --code-text-color: #037353;
+  --code-text-color: #ad1e90;
   --danger-color: #f14668;
   --danger-hover-color: #f03a5f;
   --danger-text-background-color: #fde0e6;
@@ -35,7 +35,7 @@
     --bg-dark-color: #17171a;
     --border-color: #5f6267;
     --border-hover-color: #bcbebd;
-    --code-text-color: #3ad9ac;
+    --code-text-color: #cea4ea;
     --danger-color: #770018;
     --danger-hover-color: #6b0015;
     --danger-text-background-color: #770018;


### PR DESCRIPTION
I find the green color a little distracting. It makes me think of St. Pattie's Day and money. I find this dark mode pinkish-purplish color less distracting. Also, the dark mode pinkish-purplish color fits in a bit better with the color scheme that we are using for code blocks.

I think that the dark mode pinkish-purplish color is not so purplish that it looks like a clicked link.

In light mode, to have code avoid looking like clicked links, I shifted the hue more toward outright pink.

| Before (dark) | After (dark) |
| - | - |
| ![image](https://github.com/user-attachments/assets/94e936d3-ba2f-40f4-ba71-bb2de93bee0c) | ![image](https://github.com/user-attachments/assets/7460e71b-07f5-454e-8198-7ae2132dc524) |

Before and After (light mode):

![image](https://github.com/user-attachments/assets/12d4bfd1-1c38-4890-8e40-a893ab9ca206)