### PR TITLE
Remove pnpm minimumReleaseAgeExclude list

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,31 +3,3 @@ allowBuilds:
   esbuild: true
   '@tailwindcss/oxide': true
 minimumReleaseAge: 7200 # Wait 5 days before installing new releases.
-minimumReleaseAgeExclude:
-  - '@esbuild/aix-ppc64@0.28.1'
-  - '@esbuild/android-arm64@0.28.1'
-  - '@esbuild/android-arm@0.28.1'
-  - '@esbuild/android-x64@0.28.1'
-  - '@esbuild/darwin-arm64@0.28.1'
-  - '@esbuild/darwin-x64@0.28.1'
-  - '@esbuild/freebsd-arm64@0.28.1'
-  - '@esbuild/freebsd-x64@0.28.1'
-  - '@esbuild/linux-arm64@0.28.1'
-  - '@esbuild/linux-arm@0.28.1'
-  - '@esbuild/linux-ia32@0.28.1'
-  - '@esbuild/linux-loong64@0.28.1'
-  - '@esbuild/linux-mips64el@0.28.1'
-  - '@esbuild/linux-ppc64@0.28.1'
-  - '@esbuild/linux-riscv64@0.28.1'
-  - '@esbuild/linux-s390x@0.28.1'
-  - '@esbuild/linux-x64@0.28.1'
-  - '@esbuild/netbsd-arm64@0.28.1'
-  - '@esbuild/netbsd-x64@0.28.1'
-  - '@esbuild/openbsd-arm64@0.28.1'
-  - '@esbuild/openbsd-x64@0.28.1'
-  - '@esbuild/openharmony-arm64@0.28.1'
-  - '@esbuild/sunos-x64@0.28.1'
-  - '@esbuild/win32-arm64@0.28.1'
-  - '@esbuild/win32-ia32@0.28.1'
-  - '@esbuild/win32-x64@0.28.1'
-  - esbuild@0.28.1


### PR DESCRIPTION
We added this so that our lockfile would be okay after adding `minimumReleaseAge: 7200`. Now that it has been more than 7200 minutes since we added that constraint, we don't need this list of excludes anymore.