### PR TITLE
[Gemfile] Remove 'bridgetown' version constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby file: '.ruby-version'
 
 source 'https://rubygems.org', cooldown: 5
 
-gem 'bridgetown', '~> 2.2.2'
+gem 'bridgetown'
 
 group :development do
   gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  bridgetown (~> 2.2.2)
+  bridgetown
   bridgetown-feed
   bridgetown-seo-tag
   bridgetown-sitemap


### PR DESCRIPTION
The version constraint goes all the way back to the initial commit (eacd1150). I guess that the bridgetown generator that probably created the `Gemfile` added it. However, I like to keep my `Gemfile`s clean, and I don't think we are really getting any advantage from the version constraint. Therefore, this change removes it.