### PR TITLE
[github-action] Relax pnpm/action-setup pnpm version constraint

### DIFF
--- a/.github/workflows/verify_or_deploy.yml
+++ b/.github/workflows/verify_or_deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: '11.11.0' # https://github.com/pnpm/action-setup/issues/276
+          version: 11
           run_install: false
 
       - name: Set up Node


### PR DESCRIPTION
Apparently the issue that motivated the pin to a specific patch version (in #1210) has been fixed in pnpm 11.13.0 (per https://github.com/pnpm/action-setup/issues/ 276#issuecomment-4965711055 ).